### PR TITLE
Fixes to flowData_mod() and infusionData_mod() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.Rproj.user
+*.Rproj
+*.Rhistory

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .DS_Store
 .Rproj.user
 *.Rproj
-<<<<<<< HEAD
 *.Rhistory
-=======
-*.Rhistory
->>>>>>> f5338d5788d097438d19c4049824565706766616
+


### PR DESCRIPTION
When the pipeline is run on the small vignette dataset, several subfunctions in the run_MedStrI() function produced errors since they expect a dataframe or non-missing value. Add fixes to check for size of objects to avoid these errors